### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ More information can be found [here](https://www.trendmicro.com/en_au/business/p
     mkdir /tmp/python
     cd /tmp/python
     pip3 install --target=/tmp/python trend-app-protect
-    zip -r trend.zip python
+    zip -r trend.zip /tmp/python
     aws lambda publish-layer-version \
         --layer-name app-protect \
         --description "App Protect" \


### PR DESCRIPTION
Line 16 (zip command) throws a syntax error on Mac OS. Specifying full path to /python.